### PR TITLE
Refactor class hierarchy

### DIFF
--- a/river/ensemble/aggregated_mondrian_forest.py
+++ b/river/ensemble/aggregated_mondrian_forest.py
@@ -204,3 +204,7 @@ class AMFClassifier(AMFLearner, base.Classifier):
                 scores[c] += predictions[c] / self.n_estimators
 
         return scores
+
+    @property
+    def _multiclass(self):
+        return True

--- a/river/tree/mondrian/mondrian_tree.py
+++ b/river/tree/mondrian/mondrian_tree.py
@@ -13,8 +13,6 @@ class MondrianTree(abc.ABC):
 
     Parameters
     ----------
-    n_features
-        Number of features.
     step
         Step parameter of the tree.
     loss

--- a/river/tree/mondrian/mondrian_tree_classifier.py
+++ b/river/tree/mondrian/mondrian_tree_classifier.py
@@ -164,7 +164,9 @@ class MondrianTreeClassifier(MondrianTree):
             self.n_classes,
         )
 
-    def _compute_split_time(self, node: typing.Union[MondrianLeafClassifier, MondrianBranchClassifier]) -> float:
+    def _compute_split_time(
+        self, node: typing.Union[MondrianLeafClassifier, MondrianBranchClassifier]
+    ) -> float:
         """Compute the spit time of the given node.
 
         Parameters

--- a/river/tree/mondrian/mondrian_tree_classifier.py
+++ b/river/tree/mondrian/mondrian_tree_classifier.py
@@ -332,17 +332,12 @@ class MondrianTreeClassifier(MondrianTree):
                     self._update_downwards(current_node, True)
 
                     left, right = current_node.children
-                    # depth = current_node.depth + 1
 
                     # Now, get the next node
                     if is_right_extension:
                         current_node = right
                     else:
                         current_node = left
-
-                    # We update the depth of each child
-                    # left.update_depth(depth)
-                    # right.update_depth(depth)
 
                     # This is the leaf containing the sample point (we've just
                     # splitted the current node with the data point)

--- a/river/tree/mondrian/mondrian_tree_classifier.py
+++ b/river/tree/mondrian/mondrian_tree_classifier.py
@@ -74,7 +74,7 @@ class MondrianTreeClassifier(MondrianTree):
         self._classes: set[base.typing.ClfTarget] = set()
 
         # The current sample being proceeded
-        self._x: typing.Dict[base.typing.FeatureName, int | float]
+        self._x: typing.Dict[base.typing.FeatureName, typing.Union[int, float]]
         # The current label index being proceeded
         self._y: base.typing.ClfTarget
 
@@ -150,7 +150,7 @@ class MondrianTreeClassifier(MondrianTree):
         ----------
         node
             Target node.
-        do_update_weight
+        do_weight_update
             Whether we should update the weights or not.
         """
 
@@ -164,7 +164,7 @@ class MondrianTreeClassifier(MondrianTree):
             self.n_classes,
         )
 
-    def _compute_split_time(self, node: MondrianLeafClassifier | MondrianBranchClassifier) -> float:
+    def _compute_split_time(self, node: typing.Union[MondrianLeafClassifier, MondrianBranchClassifier]) -> float:
         """Compute the spit time of the given node.
 
         Parameters
@@ -205,7 +205,7 @@ class MondrianTreeClassifier(MondrianTree):
 
     def _split(
         self,
-        node: MondrianLeafClassifier | MondrianBranchClassifier,
+        node: typing.Union[MondrianLeafClassifier, MondrianBranchClassifier],
         split_time: float,
         threshold: float,
         feature: base.typing.FeatureName,
@@ -230,8 +230,8 @@ class MondrianTreeClassifier(MondrianTree):
         new_depth = node.depth + 1
 
         # To calm down mypy
-        left: MondrianLeafClassifier | MondrianBranchClassifier
-        right: MondrianLeafClassifier | MondrianBranchClassifier
+        left: typing.Union[MondrianLeafClassifier, MondrianBranchClassifier]
+        right: typing.Union[MondrianLeafClassifier, MondrianBranchClassifier]
 
         # The node is already a branch: we create a new branch above it and move the existing
         # node one level down the tree

--- a/river/tree/mondrian/mondrian_tree_classifier.py
+++ b/river/tree/mondrian/mondrian_tree_classifier.py
@@ -261,6 +261,7 @@ class MondrianTreeClassifier(MondrianTree):
                 right.children = (old_left, old_right)
 
             # Update the level of the modified nodes
+            new_depth += 1
             old_left.update_depth(new_depth)
             old_right.update_depth(new_depth)
 

--- a/river/tree/mondrian/mondrian_tree_classifier.py
+++ b/river/tree/mondrian/mondrian_tree_classifier.py
@@ -235,11 +235,12 @@ class MondrianTreeClassifier(MondrianTree):
             # TODO check whether the logic is inverted in the following if statement
             if is_right_extension:
                 branch = MondrianBranchClassifier(
-                    node.parent, split_time, node.depth, feature, threshold
+                    node.parent, node.time, node.depth, feature, threshold
                 )
                 right = MondrianLeafClassifier(branch, split_time, new_depth)
-
+                branch.replant(node)
                 node.parent = branch
+                node.time = split_time
                 node.update_depth(new_depth)
                 branch.children = (node, right)
 
@@ -247,9 +248,11 @@ class MondrianTreeClassifier(MondrianTree):
             else:
                 left = MondrianLeafClassifier(node, split_time, new_depth)
                 branch = MondrianBranchClassifier(
-                    node.parent, split_time, node.depth, feature, threshold
+                    node.parent, node.time, node.depth, feature, threshold
                 )
+                branch.replant(node)
                 node.parent = branch
+                node.time = split_time
                 node.update_depth(new_depth)
                 branch.children = (left, node)
 
@@ -258,7 +261,7 @@ class MondrianTreeClassifier(MondrianTree):
         else:
             # Create a new branch
             branch = MondrianBranchClassifier(
-                node.parent, node.time, node.depth, feature, threshold, branch, right
+                node.parent, node.time, node.depth, feature, threshold
             )
             left = MondrianLeafClassifier(branch, split_time, new_depth)
             right = MondrianLeafClassifier(branch, split_time, new_depth)
@@ -267,7 +270,7 @@ class MondrianTreeClassifier(MondrianTree):
             # Copy properties from the previous leaf
             branch.replant(node)
             # To avoid leaving garbage behind
-            node.parent = None
+            del node
 
             return branch
 
@@ -297,13 +300,8 @@ class MondrianTreeClassifier(MondrianTree):
 
                     # We normalize the range extensions to get probabilities
                     intensities_sum = math.fsum(list(self.intensities.values()))
-<<<<<<< HEAD
-                    for key in self.intensities:
-                        self.intensities[key] /= intensities_sum
-=======
                     for k in self.intensities:
                         self.intensities[k] /= intensities_sum
->>>>>>> 5d969f4c (refactoring)
 
                     # Sample the feature at random with a probability
                     # proportional to the range extensions
@@ -334,7 +332,7 @@ class MondrianTreeClassifier(MondrianTree):
                     self._update_downwards(current_node, True)
 
                     left, right = current_node.children
-                    depth = current_node.depth + 1
+                    # depth = current_node.depth + 1
 
                     # Now, get the next node
                     if is_right_extension:
@@ -343,8 +341,8 @@ class MondrianTreeClassifier(MondrianTree):
                         current_node = left
 
                     # We update the depth of each child
-                    left.update_depth(depth)
-                    right.update_depth(depth)
+                    # left.update_depth(depth)
+                    # right.update_depth(depth)
 
                     # This is the leaf containing the sample point (we've just
                     # splitted the current node with the data point)
@@ -416,13 +414,9 @@ class MondrianTreeClassifier(MondrianTree):
             return {}
 
         # Initialization of the scores to output to 0
-<<<<<<< HEAD
-        scores: dict[base.typing.ClfTarget, float] = {}
-=======
         scores = {c: 0.0 for c in self._classes}
->>>>>>> 5d969f4c (refactoring)
 
-        if isinstance(MondrianBranchClassifier):
+        if isinstance(self._root, MondrianBranchClassifier):
             leaf = self._root.traverse(x, until_leaf=True)
         else:
             leaf = self._root

--- a/river/tree/mondrian/mondrian_tree_nodes.py
+++ b/river/tree/mondrian/mondrian_tree_nodes.py
@@ -43,11 +43,13 @@ class MondrianBranch(Branch):
         self.feature = feature
         self.threshold = threshold
 
-    def next(self, x):
-        left, right = self.children
+    def branch_no(self, x) -> int:
         if x[self.feature] <= self.threshold:
-            return left
-        return right
+            return 0
+        return 1
+
+    def next(self, x):
+        return self.children[self.branch_no(x)]
 
     def most_common_path(self):
         left, right = self.children
@@ -155,11 +157,16 @@ class MondrianNodeClassifier(MondrianNode):
         self.counts = collections.defaultdict(int)
 
     # TODO check if there is something missing here
-    def replant(self, leaf: "MondrianNodeClassifier"):
+    def replant(self, leaf: "MondrianNodeClassifier", copy_all: bool = False):
         """Transfer information from a leaf to a new branch."""
         self.weight = leaf.weight  # type: ignore
         self.log_weight_tree = leaf.log_weight_tree  # type: ignore
         self.counts = leaf.counts
+
+        if copy_all:
+            self.memory_range_min = leaf.memory_range_min
+            self.memory_range_max = leaf.memory_range_max
+            self.n_samples = leaf.n_samples
 
     def score(self, sample_class: base.typing.ClfTarget, dirichlet: float, n_classes: int) -> float:
         """Compute the score of the node.

--- a/river/tree/mondrian/mondrian_tree_nodes.py
+++ b/river/tree/mondrian/mondrian_tree_nodes.py
@@ -249,7 +249,7 @@ class MondrianNodeClassifier(MondrianNode):
 
         loss_t = self.loss(sample_class, dirichlet, n_classes)
         if use_aggregation:
-            self.weight -= step * loss_t  # type: ignore
+            self.weight -= step * loss_t
         return loss_t
 
     def update_count(self, sample_class):

--- a/river/tree/mondrian/mondrian_tree_nodes.py
+++ b/river/tree/mondrian/mondrian_tree_nodes.py
@@ -368,5 +368,6 @@ class MondrianBranchClassifier(MondrianNodeClassifier, MondrianBranch):
     *children
         Children nodes of the branch.
     """
+
     def __init__(self, parent, time, depth, feature, threshold, *children):
         super().__init__(parent, time, depth, feature, threshold, *children)

--- a/river/tree/mondrian/mondrian_tree_nodes.py
+++ b/river/tree/mondrian/mondrian_tree_nodes.py
@@ -128,7 +128,7 @@ class MondrianNode(base.Base):
 
         Parameters
         ----------
-        x_t
+        x
             Sample to deal with.
         extensions
             List of range extension per feature to update.
@@ -156,12 +156,10 @@ class MondrianNodeClassifier(MondrianNode):
         self.n_samples = 0
         self.counts = collections.defaultdict(int)
 
-    # TODO check if there is something missing here
     def replant(self, leaf: "MondrianNodeClassifier", copy_all: bool = False):
         """Transfer information from a leaf to a new branch."""
         self.weight = leaf.weight  # type: ignore
         self.log_weight_tree = leaf.log_weight_tree  # type: ignore
-        self.counts = leaf.counts
 
         if copy_all:
             self.memory_range_min = leaf.memory_range_min
@@ -294,7 +292,7 @@ class MondrianNodeClassifier(MondrianNode):
 
         Parameters
         ----------
-        x_t
+        x
             Sample to proceed (as a list).
         sample_class
             Class of the sample x_t.
@@ -352,9 +350,23 @@ class MondrianLeafClassifier(MondrianNodeClassifier, MondrianLeaf):
         super().__init__(parent, time, depth)
 
 
-# TODO add documentation
 class MondrianBranchClassifier(MondrianNodeClassifier, MondrianBranch):
-    """Mondrian Tree Classifier branch node."""
+    """Mondrian Tree Classifier branch node.
 
+    Parameters
+    ----------
+    parent
+        Parent node of the branch.
+    time
+        Split time characterizing the branch.
+    depth
+        Depth of the branch in the tree.
+    feature
+        Feature of the branch.
+    threshold
+        Acceptation threshold of the branch.
+    *children
+        Children nodes of the branch.
+    """
     def __init__(self, parent, time, depth, feature, threshold, *children):
         super().__init__(parent, time, depth, feature, threshold, *children)

--- a/river/tree/mondrian/mondrian_tree_nodes.py
+++ b/river/tree/mondrian/mondrian_tree_nodes.py
@@ -159,9 +159,6 @@ class MondrianNodeClassifier(MondrianNode):
         """Transfer information from a leaf to a new branch."""
         self.weight = leaf.weight  # type: ignore
         self.log_weight_tree = leaf.log_weight_tree  # type: ignore
-        self.memory_range_min = leaf.memory_range_min
-        self.memory_range_max = leaf.memory_range_max
-        self.n_samples = leaf.n_samples
         self.counts = leaf.counts
 
     def score(self, sample_class: base.typing.ClfTarget, dirichlet: float, n_classes: int) -> float:


### PR DESCRIPTION
*Disclaimer:* there are some silly bugs I still didn't find. They are affecting performance.

The idea for refactoring:

- Branches and leaves in Mondrian Trees share some common properties, so I introduced the `MondrianNode{Classifier}` class. The base `MondrianLeaf` and `MondrianBranch` only define some basic tree-based actions.
- `MondrianNodeClassifier` defines everything classification-related. `MondrianNode` could even become an abstract class with `score`, `predict`, `loss`, and other methods being abstract.
- The concrete `MondrianLeafClassifier` and `MondrianBranchClassifier` are basically stubs that work by joining `MondrianNodeClassifier x {MondrianLeaf, MondrianBranch}` (order matters here).
I also dropped some properties from the nodes, for instance, `classes`. The main tree already keeps that. At the moment, I'm treating `len(tree._classes) != tree.n_classes` (the latter parameter passed at initialization). So, sometimes I pass both values as parameters in method calls. If, in the future, we drop the `n_classes` parameter, we should update the method calls accordingly.

